### PR TITLE
Fix sort on category pages

### DIFF
--- a/libs/smartyvariables.php
+++ b/libs/smartyvariables.php
@@ -178,6 +178,11 @@ if($pligg_category != ''){
 	$main_smarty->assign('index_url_month', getmyurl('index_sort', 'month', $pligg_category));
 	$main_smarty->assign('index_url_year', getmyurl('index_sort', 'year', $pligg_category));
 	$main_smarty->assign('index_url_alltime', getmyurl('index_sort', 'alltime', $pligg_category));
+	
+	$main_smarty->assign('index_url_upvoted', getmyurl('index_sort', 'upvoted', $pligg_category));
+	$main_smarty->assign('index_url_downvoted', getmyurl('index_sort', 'downvoted', $pligg_category));
+	$main_smarty->assign('index_url_commented', getmyurl('index_sort', 'commented', $pligg_category));
+	
 	$main_smarty->assign('cat_url', getmyurl("maincategory"));
 }	
 else {


### PR DESCRIPTION
Sorting by most upvoted, most downvoted and most commented did not work when viewing a specific category.

This change sets up the `index_url_upvoted`, `index_url_downvoted` and `index_url_commented` smarty variables on category pages in the same way as the date sorting variables.
