### PR TITLE
Fix an issue where administrators are unable to use editgroup.php

### DIFF
--- a/editgroup.php
+++ b/editgroup.php
@@ -17,8 +17,7 @@ if(!is_numeric($requestID)){$requestID = 0;}
 if(isset($_REQUEST['title'])){$requestTitle = $db->escape(strip_tags($_REQUEST['title']));}
 
 //check group admin
-$canIhaveAccess = checklevel('admin');
-$canIhaveAccess = checklevel('moderator');
+$canIhaveAccess = checklevel('admin') || checklevel('moderator');
 
 if($current_user->user_id != get_group_creator($requestID) && $canIhaveAccess != 1)
 {


### PR DESCRIPTION
The logic for checking if the user is an administrator OR a moderator was broken.
